### PR TITLE
Add file system support

### DIFF
--- a/Nop.Plugin.Misc.Watermark/Services/MiscWatermarkPictureService.cs
+++ b/Nop.Plugin.Misc.Watermark/Services/MiscWatermarkPictureService.cs
@@ -82,7 +82,9 @@ namespace Nop.Plugin.Misc.Watermark.Services
                     if (watermarkPictureId != 0)
                     {
                         Picture picture = base.GetPictureById(watermarkPictureId);
-                        using (MemoryStream ms = new MemoryStream(picture.PictureBinary))
+                        if (picture != null)
+                            pictureBinary = LoadPictureBinary(picture);
+                        using (MemoryStream ms = new MemoryStream(pictureBinary))
                         {
                             return new Bitmap(ms);
                         }

--- a/Nop.Plugin.Misc.Watermark/Services/MiscWatermarkPictureService.cs
+++ b/Nop.Plugin.Misc.Watermark/Services/MiscWatermarkPictureService.cs
@@ -82,6 +82,7 @@ namespace Nop.Plugin.Misc.Watermark.Services
                     if (watermarkPictureId != 0)
                     {
                         Picture picture = base.GetPictureById(watermarkPictureId);
+                        byte[] pictureBinary = null;
                         if (picture != null)
                             pictureBinary = LoadPictureBinary(picture);
                         using (MemoryStream ms = new MemoryStream(pictureBinary))


### PR DESCRIPTION
As I reported [#2](https://github.com/MarinaAndreeva/nopWatermark/issues/2) when file system is chosen in Media settings as picture storage place, nopWatermark plugin won't work and returns "Parameter is not valid" exception, this update fixes the problem.
Method GetPictureById doesn't fill picture.PictureBinary when file system is chosen as picture storage place in Media settings, causing "parameter is not valid" error.
Method LoadPictureBinary considers storage settings and returns picture binary according to storage settings in Media settings.