### PR TITLE
The first store id is 1

### DIFF
--- a/Nop.Plugin.Misc.Watermark/Services/MiscWatermarkPictureService.cs
+++ b/Nop.Plugin.Misc.Watermark/Services/MiscWatermarkPictureService.cs
@@ -137,7 +137,7 @@ namespace Nop.Plugin.Misc.Watermark.Services
                 .Id;
             string lastPart = GetFileExtensionFromMimeType(picture.MimeType);
             string thumbFileName;
-            if (storeId == 0)
+            if (storeId == 1)
             {
                 if (targetSize == 0)
                 {


### PR DESCRIPTION
The first store id equals 1
The code `if (storeId == 0)` never executes because the first store id equals one, and the `else` part of the code executes which adds a "_1" to the generated images even when there is only one store.